### PR TITLE
Fix Kubernetes deployment

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -14,20 +14,32 @@ spec:
       labels:
         app: speedspy
     spec:
+      initContainers:
+        # Creates the database file if it does not exist
+        # Otherwise it would be mounted as a directory in the app container
+        - name: touch-db
+          image: busybox
+          args: ['/bin/touch', '/tmp/db/speedrunners.db']
+          volumeMounts:
+            - name: runner-database
+              mountPath: /tmp/db
+              subPath: db
       containers:
         - name: speedspy
           image: vauhtijuoksu.azurecr.io/vauhtijuoksu/speedspy:dev
           imagePullPolicy: Always
+          command: ['python', 'spyBot.py']
           volumeMounts:
             - name: bot-configs
-              mountPath: /app
-              subPath: .env
+              mountPath: /app/.env
+              subPath: prod.env
             - name: runner-database
-              mountPath: /app/database
+              mountPath: /app/speedrunners.db
+              subPath: db/speedrunners.db
       volumes:
         - name: bot-configs
           configMap:
             name: speedspy-config
         - name: runner-database
-          hostPath:
-            path: speedrunners.db
+          persistentVolumeClaim:
+            claimName: speedspy-db

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: speedspy-db
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: azurefile-sqlite
+  resources:
+    requests:
+      storage: 64Mi

--- a/templates/sc.yaml
+++ b/templates/sc.yaml
@@ -1,0 +1,17 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: azurefile-sqlite
+provisioner: kubernetes.io/azure-file
+allowVolumeExpansion: true
+mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=0
+  - gid=0
+  - mfsymlinks
+  - nobrl
+  - cache=strict
+parameters:
+  skuName: Standard_LRS


### PR DESCRIPTION
- Added command to run bot in container
- Added custom StorageClass template for sqlite databases
- Added PersistentVolumeClaim template for the sqlite db
- Mounted sqlite database as PVC insted of hostPath
- Added initContainer with busybox to create db file to PVC, so it mounts as file instead of directory
- Fixed .env configmap mount subpath to mount correctly